### PR TITLE
Use "current" AWS region as `logs_region` in ECS service

### DIFF
--- a/modules/subnet_router/aws.tf
+++ b/modules/subnet_router/aws.tf
@@ -1,0 +1,19 @@
+# Copyright 2023 Hardfin, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  aws_region_name = data.aws_region.current.name
+}
+
+data "aws_region" "current" {}

--- a/modules/subnet_router/container_definitions/tailscale.json
+++ b/modules/subnet_router/container_definitions/tailscale.json
@@ -43,7 +43,7 @@
         "logDriver": "awslogs",
         "options": {
             "awslogs-group": "${logs_group}",
-            "awslogs-region": "us-east-2",
+            "awslogs-region": "${logs_region}",
             "awslogs-stream-prefix": "ecs"
         }
     },

--- a/modules/subnet_router/ecs.tf
+++ b/modules/subnet_router/ecs.tf
@@ -22,7 +22,7 @@ locals {
     image_id           = "${data.aws_ecr_repository.tailscale.repository_url}@${data.aws_ecr_image.tailscale.id}"
     volume_name        = local.tailscale_volume_name
     logs_group         = aws_cloudwatch_log_group.tailscale.name
-    logs_region        = "us-east-2"
+    logs_region        = local.aws_region_name
   })
 }
 

--- a/modules/subnet_router/ecs.tf
+++ b/modules/subnet_router/ecs.tf
@@ -22,6 +22,7 @@ locals {
     image_id           = "${data.aws_ecr_repository.tailscale.repository_url}@${data.aws_ecr_image.tailscale.id}"
     volume_name        = local.tailscale_volume_name
     logs_group         = aws_cloudwatch_log_group.tailscale.name
+    logs_region        = "us-east-2"
   })
 }
 


### PR DESCRIPTION
Fixes #2.