### PR TITLE
Additional Routes and support `cpu_architecture` override (e.g. for ARM64)

### DIFF
--- a/modules/subnet_router/ecs.tf
+++ b/modules/subnet_router/ecs.tf
@@ -17,7 +17,7 @@ locals {
   tailscale_definition_path = abspath("${path.module}/container_definitions/tailscale.json")
   tailscale_container_json = templatefile(local.tailscale_definition_path, {
     hostname           = "${var.vpc}-tailscale"
-    advertise_routes   = join(",", concat(data.aws_vpc.ecs.cidr_block, var.additional_routes))
+    advertise_routes   = join(",", concat([data.aws_vpc.ecs.cidr_block], var.additional_routes))
     auth_key_secret_id = data.aws_secretsmanager_secret.tailscale_auth_key.id
     image_id           = "${data.aws_ecr_repository.tailscale.repository_url}@${data.aws_ecr_image.tailscale.id}"
     volume_name        = local.tailscale_volume_name

--- a/modules/subnet_router/ecs.tf
+++ b/modules/subnet_router/ecs.tf
@@ -17,7 +17,7 @@ locals {
   tailscale_definition_path = abspath("${path.module}/container_definitions/tailscale.json")
   tailscale_container_json = templatefile(local.tailscale_definition_path, {
     hostname           = "${var.vpc}-tailscale"
-    advertise_routes   = data.aws_vpc.ecs.cidr_block
+    advertise_routes   = join(",", concat(data.aws_vpc.ecs.cidr_block, var.additional_routes))
     auth_key_secret_id = data.aws_secretsmanager_secret.tailscale_auth_key.id
     image_id           = "${data.aws_ecr_repository.tailscale.repository_url}@${data.aws_ecr_image.tailscale.id}"
     volume_name        = local.tailscale_volume_name

--- a/modules/subnet_router/ecs.tf
+++ b/modules/subnet_router/ecs.tf
@@ -47,6 +47,11 @@ resource "aws_ecs_task_definition" "tailscale" {
       transit_encryption = "ENABLED"
     }
   }
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = var.cpu_architecture
+  }
 }
 
 data "aws_ecs_cluster" "target" {

--- a/modules/subnet_router/variables.tf
+++ b/modules/subnet_router/variables.tf
@@ -62,3 +62,9 @@ variable "additional_routes" {
   default     = []
   description = "A list of additional CIDR blocks to pass to Tailscale as routes to advertise"
 }
+
+variable "cpu_architecture" {
+  type        = string
+  default     = "X86_64"
+  description = "The CPU architecture to use for the container. Either X86_64 or ARM64."
+}

--- a/modules/subnet_router/variables.tf
+++ b/modules/subnet_router/variables.tf
@@ -56,3 +56,9 @@ variable "enable_execute_command" {
   type        = bool
   description = "Allows AWS ECS exec into the task containers"
 }
+
+variable "additional_routes" {
+  type        = list(string)
+  default     = []
+  description = "A list of additional CIDR blocks to pass to Tailscale as routes to advertise"
+}


### PR DESCRIPTION
Adds additional routes which is something we need to have a single subnet router for our multiple VPCs. Also fixes #6 for good measure.