### PR TITLE
Add additional_routes and cpu_architecture variables to root module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,4 +24,6 @@ module "subnet_router" {
   tailscale_docker_repository = var.tailscale_docker_repository
   tailscale_docker_tag        = var.tailscale_docker_tag
   enable_execute_command      = var.enable_execute_command
+  additional_routes           = var.additional_routes
+  cpu_architecture            = var.cpu_architecture
 }

--- a/variables.tf
+++ b/variables.tf
@@ -73,3 +73,15 @@ variable "enable_execute_command" {
   - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
   EOT
 }
+
+variable "additional_routes" {
+  type        = list(string)
+  default     = []
+  description = "A list of additional CIDR blocks to pass to Tailscale as routes to advertise"
+}
+
+variable "cpu_architecture" {
+  type        = string
+  default     = "X86_64"
+  description = "The CPU architecture to use for the container. Either X86_64 or ARM64."
+}


### PR DESCRIPTION
Hi there! Thanks for this project, it was great to quickly get Tailscale up and running in our AWS VPC.

I did run into a problem using a couple of the variables added in https://github.com/hardfinhq/terraform-aws-tailscale-subnet-router/pull/7, though. This was my first time using Terraform (hope to do a lot more!) so I'm not too familiar how these things are supposed to be set up, but the changeset here seemed to get things working for me. Let me know if there are any problems.