### PR TITLE
Additional Flags and Subnet Router Failover

### DIFF
--- a/_docker/tailscale-entrypoint.sh
+++ b/_docker/tailscale-entrypoint.sh
@@ -55,7 +55,8 @@ TAILSCALED_PID="${!}"
 tailscale up \
   --hostname "${TAILSCALE_HOSTNAME}" \
   --authkey "${TAILSCALE_AUTH_KEY}" \
-  --advertise-routes "${TAILSCALE_ADVERTISE_ROUTES}"
+  --advertise-routes "${TAILSCALE_ADVERTISE_ROUTES}" \
+  ${TAILSCALE_ADDITIONAL_FLAGS}
 
 ## Wait on `tailscaled`
 

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@
 module "subnet_router" {
   source = "./modules/subnet_router"
 
+  name                        = var.name
   vpc                         = var.vpc
   subnet_group                = var.subnet_group
   assign_public_ip            = var.assign_public_ip
@@ -26,4 +27,7 @@ module "subnet_router" {
   enable_execute_command      = var.enable_execute_command
   additional_routes           = var.additional_routes
   cpu_architecture            = var.cpu_architecture
+  additional_flags            = var.additional_flags
+  cpu                         = var.cpu
+  memory                      = var.memory
 }

--- a/modules/subnet_router/container_definitions/tailscale.json
+++ b/modules/subnet_router/container_definitions/tailscale.json
@@ -21,9 +21,9 @@
     ],
     "essential": true,
     "image": "${image_id}",
-    "cpu": "${cpu}",
-    "memory": "${memory}",
-    "memoryReservation": "${memory}",
+    "cpu": ${cpu},
+    "memory": ${memory},
+    "memoryReservation": ${memory},
     "name": "tailscale",
     "portMappings": [],
     "mountPoints": [

--- a/modules/subnet_router/container_definitions/tailscale.json
+++ b/modules/subnet_router/container_definitions/tailscale.json
@@ -7,6 +7,10 @@
         {
             "name": "TAILSCALE_ADVERTISE_ROUTES",
             "value": "${advertise_routes}"
+        },
+        {
+            "name": "TAILSCALE_ADDITIONAL_FLAGS",
+            "value": "${additional_flags}"
         }
     ],
     "secrets": [

--- a/modules/subnet_router/container_definitions/tailscale.json
+++ b/modules/subnet_router/container_definitions/tailscale.json
@@ -21,9 +21,9 @@
     ],
     "essential": true,
     "image": "${image_id}",
-    "cpu": 256,
-    "memory": 512,
-    "memoryReservation": 512,
+    "cpu": "${cpu}",
+    "memory": "${memory}",
+    "memoryReservation": "${memory}",
     "name": "tailscale",
     "portMappings": [],
     "mountPoints": [

--- a/modules/subnet_router/ecs.tf
+++ b/modules/subnet_router/ecs.tf
@@ -25,7 +25,7 @@ locals {
     logs_group         = aws_cloudwatch_log_group.tailscale.name
     logs_region        = local.aws_region_name
   })
-  name = var.name != "" ? var.name : "${var.vpc}-tailscale"
+  name = var.name != null ? var.name : "${var.vpc}-tailscale"
 }
 
 resource "aws_ecs_task_definition" "tailscale" {

--- a/modules/subnet_router/ecs.tf
+++ b/modules/subnet_router/ecs.tf
@@ -17,7 +17,7 @@ locals {
   tailscale_definition_path = abspath("${path.module}/container_definitions/tailscale.json")
   tailscale_container_json = templatefile(local.tailscale_definition_path, {
     hostname           = "${var.vpc}-tailscale"
-    advertise_routes   = join(",", concat([data.aws_vpc.ecs.cidr_block], var.additional_routes))
+    advertise_routes   = join(",", concat(data.aws_vpc.ecs.cidr_block, var.additional_routes))
     auth_key_secret_id = data.aws_secretsmanager_secret.tailscale_auth_key.id
     image_id           = "${data.aws_ecr_repository.tailscale.repository_url}@${data.aws_ecr_image.tailscale.id}"
     volume_name        = local.tailscale_volume_name

--- a/modules/subnet_router/ecs.tf
+++ b/modules/subnet_router/ecs.tf
@@ -60,7 +60,7 @@ data "aws_ecs_cluster" "target" {
 }
 
 resource "aws_ecs_service" "tailscale" {
-  name                   = "tailscale"
+  name                   = "${var.name}-tailscale"
   cluster                = data.aws_ecs_cluster.target.id
   task_definition        = aws_ecs_task_definition.tailscale.arn
   desired_count          = 1

--- a/modules/subnet_router/ecs.tf
+++ b/modules/subnet_router/ecs.tf
@@ -31,8 +31,8 @@ resource "aws_ecs_task_definition" "tailscale" {
   family                   = "${var.vpc}-tailscale"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = "256" # 0.25 vCPU (256/1024)
-  memory                   = "512" # 512 MiB == 0.5 GiB
+  cpu                      = var.cpu
+  memory                   = var.memory
   execution_role_arn       = aws_iam_role.ecs_task_execution_tailscale.arn
   task_role_arn            = aws_iam_role.ecs_task_tailscale.arn
 

--- a/modules/subnet_router/ecs.tf
+++ b/modules/subnet_router/ecs.tf
@@ -24,8 +24,11 @@ locals {
     volume_name        = local.tailscale_volume_name
     logs_group         = aws_cloudwatch_log_group.tailscale.name
     logs_region        = local.aws_region_name
+    cpu                = var.cpu
+    memory             = var.memory
   })
-  name = var.name != null ? var.name : "${var.vpc}-tailscale"
+  name         = var.name != null ? var.name : "${var.vpc}-tailscale"
+  service_name = var.name != null ? var.name : "tailscale"
 }
 
 resource "aws_ecs_task_definition" "tailscale" {
@@ -61,7 +64,7 @@ data "aws_ecs_cluster" "target" {
 }
 
 resource "aws_ecs_service" "tailscale" {
-  name                   = local.name
+  name                   = local.service_name
   cluster                = data.aws_ecs_cluster.target.id
   task_definition        = aws_ecs_task_definition.tailscale.arn
   desired_count          = 1

--- a/modules/subnet_router/ecs.tf
+++ b/modules/subnet_router/ecs.tf
@@ -17,7 +17,7 @@ locals {
   tailscale_definition_path = abspath("${path.module}/container_definitions/tailscale.json")
   tailscale_container_json = templatefile(local.tailscale_definition_path, {
     hostname           = "${var.vpc}-tailscale"
-    advertise_routes   = join(",", concat(data.aws_vpc.ecs.cidr_block, var.additional_routes))
+    advertise_routes   = join(",", concat([data.aws_vpc.ecs.cidr_block], var.additional_routes))
     auth_key_secret_id = data.aws_secretsmanager_secret.tailscale_auth_key.id
     image_id           = "${data.aws_ecr_repository.tailscale.repository_url}@${data.aws_ecr_image.tailscale.id}"
     volume_name        = local.tailscale_volume_name

--- a/modules/subnet_router/ecs.tf
+++ b/modules/subnet_router/ecs.tf
@@ -16,7 +16,7 @@ locals {
   tailscale_volume_name     = "var-lib-tailscale"
   tailscale_definition_path = abspath("${path.module}/container_definitions/tailscale.json")
   tailscale_container_json = templatefile(local.tailscale_definition_path, {
-    hostname           = "${var.vpc}-tailscale"
+    hostname           = "${var.name}-tailscale"
     advertise_routes   = join(",", concat([data.aws_vpc.ecs.cidr_block], var.additional_routes))
     additional_flags   = var.additional_flags
     auth_key_secret_id = data.aws_secretsmanager_secret.tailscale_auth_key.id
@@ -28,7 +28,7 @@ locals {
 }
 
 resource "aws_ecs_task_definition" "tailscale" {
-  family                   = "${var.vpc}-tailscale"
+  family                   = "${var.name}-tailscale"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = var.cpu

--- a/modules/subnet_router/ecs.tf
+++ b/modules/subnet_router/ecs.tf
@@ -18,6 +18,7 @@ locals {
   tailscale_container_json = templatefile(local.tailscale_definition_path, {
     hostname           = "${var.vpc}-tailscale"
     advertise_routes   = join(",", concat([data.aws_vpc.ecs.cidr_block], var.additional_routes))
+    additional_flags   = var.additional_flags
     auth_key_secret_id = data.aws_secretsmanager_secret.tailscale_auth_key.id
     image_id           = "${data.aws_ecr_repository.tailscale.repository_url}@${data.aws_ecr_image.tailscale.id}"
     volume_name        = local.tailscale_volume_name

--- a/modules/subnet_router/efs.tf
+++ b/modules/subnet_router/efs.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 resource "aws_efs_file_system" "tailscale" {
-  creation_token = "${var.name}-tailscale"
+  creation_token = local.name
   lifecycle_policy {
     transition_to_ia = "AFTER_30_DAYS"
   }
@@ -22,7 +22,7 @@ resource "aws_efs_file_system" "tailscale" {
   }
 
   tags = {
-    Name = "${var.name}-tailscale"
+    Name = local.name
   }
 }
 

--- a/modules/subnet_router/efs.tf
+++ b/modules/subnet_router/efs.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 resource "aws_efs_file_system" "tailscale" {
-  creation_token = "${var.vpc}-tailscale"
+  creation_token = "${var.name}-tailscale"
   lifecycle_policy {
     transition_to_ia = "AFTER_30_DAYS"
   }
@@ -22,7 +22,7 @@ resource "aws_efs_file_system" "tailscale" {
   }
 
   tags = {
-    Name = "${var.vpc}-tailscale"
+    Name = "${var.name}-tailscale"
   }
 }
 

--- a/modules/subnet_router/iam.tf
+++ b/modules/subnet_router/iam.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "ecs_tasks_assume" {
 # environment variables. See:
 # - https://docs.aws.amazon.com/AmazonECS/latest/userguide/task_execution_IAM_role.html
 resource "aws_iam_role" "ecs_task_execution_tailscale" {
-  name               = "ecs-task-execution-${var.name}-tailscale"
+  name               = "ecs-task-execution-${local.name}"
   assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume.json
 }
 
@@ -56,7 +56,7 @@ data "aws_iam_policy_document" "ecs_task_secrets_tailscale" {
 }
 
 resource "aws_iam_policy" "ecs_task_secrets_tailscale" {
-  name        = "ecs-task-secrets-${var.name}-tailscale"
+  name        = "ecs-task-secrets-${local.name}"
   description = "Permissions for ECS task execution to read secrets for Tailscale in VPC ${var.vpc}"
   policy      = data.aws_iam_policy_document.ecs_task_secrets_tailscale.json
 }
@@ -75,7 +75,7 @@ resource "aws_iam_role_policy_attachment" "ecs_task_secrets_tailscale" {
 # the role it will authenticate with. See:
 # - https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-iam-roles.html
 resource "aws_iam_role" "ecs_task_tailscale" {
-  name               = "ecs-task-${var.name}-tailscale"
+  name               = "ecs-task-${local.name}"
   assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume.json
 }
 
@@ -100,7 +100,7 @@ data "aws_iam_policy_document" "ecs_task_logs_tailscale" {
 }
 
 resource "aws_iam_policy" "ecs_task_logs_tailscale" {
-  name        = "ecs-task-logs-${var.name}-tailscale"
+  name        = "ecs-task-logs-${local.name}"
   description = "Permissions for ECS task to write logs for Tailscale in VPC ${var.vpc}"
   policy      = data.aws_iam_policy_document.ecs_task_logs_tailscale.json
 }

--- a/modules/subnet_router/iam.tf
+++ b/modules/subnet_router/iam.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "ecs_tasks_assume" {
 # environment variables. See:
 # - https://docs.aws.amazon.com/AmazonECS/latest/userguide/task_execution_IAM_role.html
 resource "aws_iam_role" "ecs_task_execution_tailscale" {
-  name               = "ecs-task-execution-${var.vpc}-tailscale"
+  name               = "ecs-task-execution-${var.name}-tailscale"
   assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume.json
 }
 
@@ -56,7 +56,7 @@ data "aws_iam_policy_document" "ecs_task_secrets_tailscale" {
 }
 
 resource "aws_iam_policy" "ecs_task_secrets_tailscale" {
-  name        = "ecs-task-secrets-${var.vpc}-tailscale"
+  name        = "ecs-task-secrets-${var.name}-tailscale"
   description = "Permissions for ECS task execution to read secrets for Tailscale in VPC ${var.vpc}"
   policy      = data.aws_iam_policy_document.ecs_task_secrets_tailscale.json
 }
@@ -75,7 +75,7 @@ resource "aws_iam_role_policy_attachment" "ecs_task_secrets_tailscale" {
 # the role it will authenticate with. See:
 # - https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-iam-roles.html
 resource "aws_iam_role" "ecs_task_tailscale" {
-  name               = "ecs-task-${var.vpc}-tailscale"
+  name               = "ecs-task-${var.name}-tailscale"
   assume_role_policy = data.aws_iam_policy_document.ecs_tasks_assume.json
 }
 
@@ -100,7 +100,7 @@ data "aws_iam_policy_document" "ecs_task_logs_tailscale" {
 }
 
 resource "aws_iam_policy" "ecs_task_logs_tailscale" {
-  name        = "ecs-task-logs-${var.vpc}-tailscale"
+  name        = "ecs-task-logs-${var.name}-tailscale"
   description = "Permissions for ECS task to write logs for Tailscale in VPC ${var.vpc}"
   policy      = data.aws_iam_policy_document.ecs_task_logs_tailscale.json
 }

--- a/modules/subnet_router/logs.tf
+++ b/modules/subnet_router/logs.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 resource "aws_cloudwatch_log_group" "tailscale" {
-  name = "/ecs/${var.name}-tailscale"
+  name = "/ecs/${local.name}"
 
   retention_in_days = 7
 }

--- a/modules/subnet_router/logs.tf
+++ b/modules/subnet_router/logs.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 resource "aws_cloudwatch_log_group" "tailscale" {
-  name = "/ecs/${var.vpc}-tailscale"
+  name = "/ecs/${var.name}-tailscale"
 
   retention_in_days = 7
 }

--- a/modules/subnet_router/variables.tf
+++ b/modules/subnet_router/variables.tf
@@ -68,3 +68,9 @@ variable "cpu_architecture" {
   default     = "X86_64"
   description = "The CPU architecture to use for the container. Either X86_64 or ARM64."
 }
+
+variable "additional_flags" {
+  type        = string
+  default     = ""
+  description = "Additional flags to pass to the tailscale up command"
+}

--- a/modules/subnet_router/variables.tf
+++ b/modules/subnet_router/variables.tf
@@ -15,7 +15,7 @@
 variable "name" {
   type        = string
   default     = null
-  description = "The name of the subnet router deployment. If unspecified the vpc name will be used."
+  description = "The name of the subnet router deployment. If unspecified the VPC name will be used."
 }
 
 variable "vpc" {
@@ -82,13 +82,13 @@ variable "additional_flags" {
 }
 
 variable "cpu" {
-  type        = string
-  default     = "256"
+  type        = number
+  default     = 256
   description = "The CPU value to assign to the container (vCPU)"
 }
 
 variable "memory" {
-  type        = string
-  default     = "512"
+  type        = number
+  default     = 512
   description = "The memory value to assign to the container (MiB)"
 }

--- a/modules/subnet_router/variables.tf
+++ b/modules/subnet_router/variables.tf
@@ -84,3 +84,8 @@ variable "memory" {
   default     = "512"
   description = "The memory value to assign to the container (MiB)"
 }
+variable "name" {
+  type = string
+  default = ""
+  description = "The name of the subnet router deployment"
+}

--- a/modules/subnet_router/variables.tf
+++ b/modules/subnet_router/variables.tf
@@ -74,3 +74,13 @@ variable "additional_flags" {
   default     = ""
   description = "Additional flags to pass to the tailscale up command"
 }
+variable "cpu" {
+  type        = string
+  default     = "256"
+  description = "The CPU value to assign to the container (vCPU)"
+}
+variable "memory" {
+  type        = string
+  default     = "512"
+  description = "The memory value to assign to the container (MiB)"
+}

--- a/modules/subnet_router/variables.tf
+++ b/modules/subnet_router/variables.tf
@@ -62,3 +62,9 @@ variable "additional_routes" {
   default     = []
   description = "A list of additional CIDR blocks to pass to Tailscale as routes to advertise"
 }
+
+variable "cpu_architecture" {
+  type        = string
+  default     = "X86_64"
+  description = "The CPU architecture to use for the container. Either X86_64 or ARM64."
+}

--- a/modules/subnet_router/variables.tf
+++ b/modules/subnet_router/variables.tf
@@ -62,9 +62,3 @@ variable "additional_routes" {
   default     = []
   description = "A list of additional CIDR blocks to pass to Tailscale as routes to advertise"
 }
-
-variable "cpu_architecture" {
-  type        = string
-  default     = "X86_64"
-  description = "The CPU architecture to use for the container. Either X86_64 or ARM64."
-}

--- a/modules/subnet_router/variables.tf
+++ b/modules/subnet_router/variables.tf
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+variable "name" {
+  type        = string
+  default     = ""
+  description = "The name of the subnet router deployment. If unspecified the vpc name will be used."
+}
+
 variable "vpc" {
   type        = string
   description = "The name of the VPC where the subnet router ECS service will be launched"
@@ -83,9 +89,4 @@ variable "memory" {
   type        = string
   default     = "512"
   description = "The memory value to assign to the container (MiB)"
-}
-variable "name" {
-  type = string
-  default = ""
-  description = "The name of the subnet router deployment"
 }

--- a/modules/subnet_router/variables.tf
+++ b/modules/subnet_router/variables.tf
@@ -14,7 +14,7 @@
 
 variable "name" {
   type        = string
-  default     = ""
+  default     = null
   description = "The name of the subnet router deployment. If unspecified the vpc name will be used."
 }
 
@@ -80,11 +80,13 @@ variable "additional_flags" {
   default     = ""
   description = "Additional flags to pass to the tailscale up command"
 }
+
 variable "cpu" {
   type        = string
   default     = "256"
   description = "The CPU value to assign to the container (vCPU)"
 }
+
 variable "memory" {
   type        = string
   default     = "512"

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+variable "name" {
+  type        = string
+  default     = null
+  description = "The name of the subnet router deployment. If unspecified the VPC name will be used."
+}
+
 variable "vpc" {
   type        = string
   description = "The name of the VPC where the subnet router ECS service will be launched"
@@ -84,4 +90,22 @@ variable "cpu_architecture" {
   type        = string
   default     = "X86_64"
   description = "The CPU architecture to use for the container. Either X86_64 or ARM64."
+}
+
+variable "additional_flags" {
+  type        = string
+  default     = ""
+  description = "Additional flags to pass to the tailscale up command"
+}
+
+variable "cpu" {
+  type        = number
+  default     = 256
+  description = "The CPU value to assign to the container (vCPU)"
+}
+
+variable "memory" {
+  type        = number
+  default     = 512
+  description = "The memory value to assign to the container (MiB)"
 }


### PR DESCRIPTION
This PR incorporates a number of changes we've made on our fork. All should be backwards compatible with the exception of the ECS Service name which will change, causing a delete/recreate.

The changes made are:
* Ability to specify arbitrary `tailscale up` flags, which we use for `--advertise-exit-node`
* Ability to specify a name for all the resources rather than just using the VPC name, which we use to have multiple deployed in a single VPC for HA/failover purposes
* Ability to specify different CPU/Memory settings for the ECS Task Definition