### PR TITLE
Add explicit ECS dependency on EFS mounts + latest Tailscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ docker build \
 
 # Optionally override the tag for the base `tailscale/tailscale` image
 docker build \
-  --build-arg TAILSCALE_TAG=v1.36.2 \
+  --build-arg TAILSCALE_TAG=v1.38.4 \
   --tag tailscale-subnet-router:v1.20230311.1 \
   --file ./_docker/tailscale.Dockerfile \
   .

--- a/_docker/tailscale.Dockerfile
+++ b/_docker/tailscale.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG TAILSCALE_TAG=v1.36.2
+ARG TAILSCALE_TAG=v1.38.4
 FROM docker.io/tailscale/tailscale:${TAILSCALE_TAG}
 
 COPY _docker/tailscale-entrypoint.sh /usr/local/bin/tailscale-entrypoint.sh

--- a/modules/subnet_router/ecs.tf
+++ b/modules/subnet_router/ecs.tf
@@ -86,4 +86,6 @@ resource "aws_ecs_service" "tailscale" {
     security_groups  = var.security_group_ids
     subnets          = data.aws_subnets.primary.ids
   }
+
+  depends_on = [aws_efs_mount_target.primary]
 }


### PR DESCRIPTION
This is just upstreaming some recent internal changes